### PR TITLE
feat: type embedding and other chasethrough fixes

### DIFF
--- a/addToBeProcessed.go
+++ b/addToBeProcessed.go
@@ -1,18 +1,28 @@
 package gengo
 
 func (s *Service) AddToBeProcessed(pkg string, name string) {
+	_ = s.HasAddedToBeProcessed(pkg, name)
+}
+
+func (s *Service) HasAddedToBeProcessed(pkg string, name string) bool {
+	s.Log.Debug().Str("pkg", pkg).Str("name", name).Msg("Adding to be processed")
+
 	for _, p := range s.ToBeProcessed {
 		if p.Name == name && p.Pkg == pkg {
-			return
+			s.Log.Trace().Str("pkg", pkg).Str("name", name).Msg("Already in to be processed queue")
+			return false
 		}
 	}
-	for _, v := range s.ReturnTypes {
+	for _, v := range s.Components {
 		if v.Name == name && v.Package == pkg {
-			return
+			s.Log.Trace().Str("pkg", pkg).Str("name", name).Msg("Already processed")
+			return false
 		}
 	}
 	s.ToBeProcessed = append(s.ToBeProcessed, Processable{
 		Name: name,
 		Pkg:  pkg,
 	})
+
+	return true
 }

--- a/clean.go
+++ b/clean.go
@@ -6,8 +6,8 @@ func (s *Service) clean() error {
 		return err
 	}
 
-	for i := 0; i < len(s.ReturnTypes); i++ {
-		f := s.ReturnTypes[i]
+	for i := 0; i < len(s.Components); i++ {
+		f := s.Components[i]
 		if f.Package == mainPkg {
 			f.Package = "main"
 		}
@@ -19,7 +19,7 @@ func (s *Service) clean() error {
 			}
 		}
 
-		s.ReturnTypes[i] = f
+		s.Components[i] = f
 	}
 
 	return nil

--- a/clean.go
+++ b/clean.go
@@ -8,6 +8,9 @@ func (s *Service) clean() error {
 
 	for i := 0; i < len(s.Components); i++ {
 		f := s.Components[i]
+
+		s.handleSpecialType(&f)
+
 		if f.Package == mainPkg {
 			f.Package = "main"
 		}

--- a/inputs/gin/parseFunction.go
+++ b/inputs/gin/parseFunction.go
@@ -197,22 +197,20 @@ func parseFunction(s *gengo.Service, log zerolog.Logger, currRoute *gengo.Route,
 					currRoute.ReturnTypes = utils.AddReturnType(currRoute.ReturnTypes, returnType)
 					return true
 				case "Status": // c.Status
-					if len(currRoute.ReturnTypes) == 0 {
-						var statusCode int
-						statusCode, err = extractStatusCode(callExpr.Args[0])
-						if err != nil {
-							return false
-						}
-
-						returnType := gengo.ReturnType{
-							StatusCode: statusCode,
-							Field: gengo.Field{
-								Type: "nil",
-							},
-						}
-						currRoute.ReturnTypes = utils.AddReturnType(currRoute.ReturnTypes, returnType)
-						return true
+					var statusCode int
+					statusCode, err = extractStatusCode(callExpr.Args[0])
+					if err != nil {
+						return false
 					}
+
+					returnType := gengo.ReturnType{
+						StatusCode: statusCode,
+						Field: gengo.Field{
+							Type: "nil",
+						},
+					}
+					currRoute.ReturnTypes = utils.AddReturnType(currRoute.ReturnTypes, returnType)
+					return true
 				// Query Param methods
 				case "GetQuery":
 					fallthrough

--- a/new.go
+++ b/new.go
@@ -19,7 +19,7 @@ func New(cfgs ...Option) *Service {
 
 	s.Routes = make([]Route, 0)
 	s.ToBeProcessed = make([]Processable, 0)
-	s.ReturnTypes = make([]Field, 0)
+	s.Components = make([]Field, 0)
 
 	s.Log.Debug().Msg("Service created")
 

--- a/outputs/json/generate.go
+++ b/outputs/json/generate.go
@@ -8,16 +8,16 @@ import (
 )
 
 type JSONOutput struct {
-	Routes []gengo.Route `json:"routes"`
-	Fields []gengo.Field `json:"fields"`
+	Routes     []gengo.Route `json:"routes"`
+	Components []gengo.Field `json:"components"`
 }
 
 func generate(filePath string) gengo.GenerateFunction {
 	return func(s *gengo.Service) error {
 		s.Log.Info().Msg("Generating JSON output")
 		output := JSONOutput{
-			Routes: s.Routes,
-			Fields: s.ReturnTypes,
+			Routes:     s.Routes,
+			Components: s.Components,
 		}
 
 		s.Log.Debug().Msg("Generated JSON output")

--- a/outputs/openapi/accepted.go
+++ b/outputs/openapi/accepted.go
@@ -5,31 +5,6 @@ type openAPIJSONType struct {
 	Format string
 }
 
-var AcceptedTypes = []string{
-	"nil",
-	"string",
-	"int",
-	"int8",
-	"int16",
-	"int32",
-	"int64",
-	"uint",
-	"uint8",
-	"uint16",
-	"uint32",
-	"uint64",
-	"float",
-	"float32",
-	"float64",
-	"bool",
-	"byte",
-	"rune",
-	"struct",
-	"map",
-	"slice",
-	"any",
-}
-
 var acceptedTypeMap = map[string]openAPIJSONType{
 	"string": openAPIJSONType{
 		Type: "string",
@@ -110,14 +85,19 @@ var acceptedTypeMap = map[string]openAPIJSONType{
 		Type: "",
 	},
 	"nil": openAPIJSONType{
-		Type: "null",
+		Type: "",
 	},
 }
 
-func mapAcceptedType(acceptedType string) openAPIJSONType {
+func mapAcceptedType(acceptedType string) Schema {
 	if acceptedType, ok := acceptedTypeMap[acceptedType]; ok {
-		return acceptedType
+		if acceptedType.Type == "" {
+			return Schema{}
+		}
+		return Schema{
+			Type: acceptedType.Type,
+		}
 	}
 
-	return openAPIJSONType{}
+	return Schema{}
 }

--- a/outputs/openapi/generate.go
+++ b/outputs/openapi/generate.go
@@ -218,7 +218,7 @@ func generate(filePath string) gengo.GenerateFunction {
 		}
 
 		s.Log.Debug().Msg("Adding components")
-		for _, component := range s.ReturnTypes {
+		for _, component := range s.Components {
 			s.Log.Debug().Str("name", component.Name).Msg("Adding component")
 			var schema Schema
 			if component.Type == "struct" {

--- a/service.go
+++ b/service.go
@@ -19,5 +19,5 @@ type Service struct {
 
 	tempMainPackageName string
 
-	ReturnTypes []Field
+	Components []Field
 }

--- a/specialTypes.go
+++ b/specialTypes.go
@@ -1,0 +1,19 @@
+package gengo
+
+import "fmt"
+
+var specialTypes = map[string]string{
+	"time.Time": "string", // We can assume that all time.Time types will be serialized as strings
+}
+
+func (s *Service) handleSpecialType(component *Field) {
+	if _, ok := specialTypes[fmt.Sprintf("%s.%s", component.Package, component.Name)]; ok {
+		s.Log.Debug().Type("pkg", component.Package).Str("type", component.Name).Msg("Mapping special case")
+
+		component.Type = specialTypes[fmt.Sprintf("%s.%s", component.Package, component.Name)]
+
+		component.StructFields = nil
+		component.SliceType = ""
+		component.MapValue = ""
+	}
+}

--- a/types.go
+++ b/types.go
@@ -37,12 +37,14 @@ type Field struct {
 	Type    string `json:"type,omitempty"`
 	Name    string `json:"name,omitempty"`
 
+	IsRequired bool `json:"isRequired,omitempty"`
+	IsEmbedded bool `json:"isEmbedded,omitempty"`
+
 	SliceType string `json:"sliceType,omitempty"`
 
 	MapKeyPkg string `json:"mapKeyPkg,omitempty"`
 	MapKey    string `json:"mapKey,omitempty"`
 	MapValue  string `json:"mapValue,omitempty"`
 
-	IsRequired   bool             `json:"isRequired,omitempty"`
 	StructFields map[string]Field `json:"structFields,omitempty"`
 }

--- a/types.go
+++ b/types.go
@@ -5,7 +5,7 @@ type Route struct {
 	Path        string       `json:"path"`
 	ContentType string       `json:"contentType,omitempty"`
 	BodyType    string       `json:"bodyType,omitempty"`
-	PathParams  []Param      `json:"params,omitempty"`
+	PathParams  []Param      `json:"params,omitempty"` // for now, we use :param in the path to denote a required path param, and *param to denote an optional path param
 	QueryParams []Param      `json:"queryParams,omitempty"`
 	Body        []Param      `json:"body,omitempty"`
 	ReturnTypes []ReturnType `json:"returnTypes,omitempty"`

--- a/utils/pathParams.go
+++ b/utils/pathParams.go
@@ -1,0 +1,32 @@
+package utils
+
+import (
+	"github.com/ls6-events/gengo"
+	"regexp"
+)
+
+func getPathParamRegex() *regexp.Regexp {
+	return regexp.MustCompile(`:[^\/]+|\*[^\/]+`)
+}
+
+func ExtractParamsFromPath(path string) []gengo.Param {
+	resultParams := make([]gengo.Param, 0)
+
+	paramRegex := getPathParamRegex()
+	if paramRegex.MatchString(path) {
+		params := paramRegex.FindAllString(path, -1)
+		for _, param := range params {
+			resultParams = append(resultParams, gengo.Param{
+				Name:       param[1:],
+				Type:       "string",
+				IsRequired: param[0] == ':',
+			})
+		}
+	}
+
+	return resultParams
+}
+
+func MapPathParams(path string, repl func(string) string) string {
+	return getPathParamRegex().ReplaceAllStringFunc(path, repl)
+}

--- a/utils/returnTypes.go
+++ b/utils/returnTypes.go
@@ -15,7 +15,7 @@ func AddReturnType(prev []gengo.ReturnType, n ...gengo.ReturnType) []gengo.Retur
 			prev = append(prev, newReturn)
 		} else {
 			for _, existingReturn := range prev {
-				if newReturn.Field.Type != existingReturn.Field.Type && newReturn.Field.Package != existingReturn.Field.Package && newReturn.StatusCode != existingReturn.StatusCode {
+				if newReturn.Field.Type != existingReturn.Field.Type || newReturn.Field.Package != existingReturn.Field.Package || newReturn.StatusCode != existingReturn.StatusCode {
 					prev = append(prev, newReturn)
 					break
 				}

--- a/utils/returnTypes.go
+++ b/utils/returnTypes.go
@@ -2,14 +2,9 @@ package utils
 
 import (
 	"github.com/ls6-events/gengo"
-	"sync"
 )
 
-var mut sync.Mutex
-
 func AddReturnType(prev []gengo.ReturnType, n ...gengo.ReturnType) []gengo.ReturnType {
-	mut.Lock()
-	defer mut.Unlock()
 	for _, newReturn := range n {
 		if len(prev) == 0 {
 			prev = append(prev, newReturn)


### PR DESCRIPTION
Using a complex project, we can now follow through structs during the `process` phase better, and accounting for "special" types with the one example of `time.Time`.

Also the OpenAPI implementation was fixed so the user can have multiple different routes with just a status code response type and have multiple methods for the same endpoint - also mapped the parameters for OpenAPI friendliness.

Finally, added accountability for struct type embedding, and utilised `allOf` keyword for OpenAPI spec where appropriate.