### PR TITLE
feat: allow for inline functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,12 @@ func main() {
 	r.POST("/posts", CreatePost)
 	r.PUT("/posts/:id", UpdatePost)
 	r.DELETE("/posts/:id", DeletePost)
+	
+	r.GET("/health", func(c *gin.Context) {
+        c.JSON(200, gin.H{
+            "status": "ok",
+        })
+    })
 
 	// We need to pass in the gin.Engine instance to the input, this needs to be done before Parse()
 	// We also need an output instance, in this case we are using JSON
@@ -90,6 +96,12 @@ func main() {
 	r.POST("/posts", CreatePost)
 	r.PUT("/posts/:id", UpdatePost)
 	r.DELETE("/posts/:id", DeletePost)
+
+	r.GET("/health", func(c *gin.Context) {
+		c.JSON(200, gin.H{
+			"status": "ok",
+		})
+	})
 	
 	gen := gengo.New(gengoGin.WithGinInput(r), openapi.WithOpenAPIOutput("openapi.yaml"))
 
@@ -145,9 +157,9 @@ We have methods to extract types from the following:
 * Functions in the dependency tree
 * Functions in the `main` package
 * Anywhere that utilises the `gin.Context` type
+* Functions from inline functions (_but it has to be set inside the function where you specify your routes_)
 
 ### Upcoming features
-* Extract types from inline functions
 * Allow custom status codes nested inside packages (here we only allow for preset constants (i.e. 200), or the `http.Status*` constants)
 * Extract types from other web frameworks as inputs (e.g. [Echo](https://github.com/labstack/echo), [Fiber](https://github.com/gofiber/fiber), etc.)
 * Add support for more output formats (e.g. TypeScript interfaces/classes etc.)

--- a/inputs/gin/parseFunction.go
+++ b/inputs/gin/parseFunction.go
@@ -11,7 +11,7 @@ import (
 	"strings"
 )
 
-func extractContext(node *ast.FuncDecl) (string, error) {
+func extractContext(node *ast.FuncLit) (string, error) {
 	var ctxName string
 	for _, param := range node.Type.Params.List {
 		if len(param.Names) == 0 {
@@ -98,7 +98,7 @@ func extractStatusCode(status ast.Node) (int, error) {
 	return statusCode, nil
 }
 
-func parseFunction(s *gengo.Service, log zerolog.Logger, currRoute *gengo.Route, node *ast.FuncDecl, imports []*ast.ImportSpec, pkgName, pkgPath string, level int) error {
+func parseFunction(s *gengo.Service, log zerolog.Logger, currRoute *gengo.Route, node *ast.FuncLit, imports []*ast.ImportSpec, pkgName, pkgPath string, level int) error {
 	// Get the variable name of the context parameter
 	ctxName, err := extractContext(node)
 	if err != nil {
@@ -484,7 +484,7 @@ func parseFunction(s *gengo.Service, log zerolog.Logger, currRoute *gengo.Route,
 						return true
 					}
 
-					err = parseFunction(s, log, currRoute, funcDecl, nImports, nPkg.Name, nPkgPath, level+1)
+					err = parseFunction(s, log, currRoute, utils.FuncDeclToFuncLit(funcDecl), nImports, nPkg.Name, nPkgPath, level+1)
 					if err != nil {
 						return false
 					}
@@ -543,7 +543,7 @@ func parseFunction(s *gengo.Service, log zerolog.Logger, currRoute *gengo.Route,
 				}
 
 				nSplitPkg := strings.Split(nPkgPath, "/")
-				err = parseFunction(s, log, currRoute, funcDecl, nImports, nSplitPkg[len(nSplitPkg)-1], strings.Join(nSplitPkg[:len(nSplitPkg)-1], "/"), level+1)
+				err = parseFunction(s, log, currRoute, utils.FuncDeclToFuncLit(funcDecl), nImports, nSplitPkg[len(nSplitPkg)-1], strings.Join(nSplitPkg[:len(nSplitPkg)-1], "/"), level+1)
 				if err != nil {
 					return false
 				}

--- a/inputs/gin/populate.go
+++ b/inputs/gin/populate.go
@@ -12,14 +12,16 @@ func populate(router *gin.Engine) gengo.PopulateFunction {
 		s.Log.Debug().Msg("Populating service with gin routes")
 		for _, route := range router.Routes() {
 			s.Log.Debug().Str("path", route.Path).Str("method", route.Method).Msg("Populating route")
-			pc := reflect.ValueOf(route.HandlerFunc).Pointer()
-			file, _ := runtime.FuncForPC(pc).FileLine(pc)
-			s.Log.Debug().Str("path", route.Path).Str("method", route.Method).Str("file", file).Msg("Found route handler")
 
-			s.Log.Debug().Str("path", route.Path).Str("method", route.Method).Str("file", file).Msg("Parsing route")
-			err := parseRoute(s, file, route)
+			pc := reflect.ValueOf(route.HandlerFunc).Pointer()
+			file, line := runtime.FuncForPC(pc).FileLine(pc)
+
+			s.Log.Debug().Str("path", route.Path).Str("method", route.Method).Str("file", file).Int("line", line).Msg("Found route handler")
+
+			s.Log.Debug().Str("path", route.Path).Str("method", route.Method).Str("file", file).Int("line", line).Msg("Parsing route")
+			err := parseRoute(s, file, line, route)
 			if err != nil {
-				s.Log.Error().Str("path", route.Path).Str("method", route.Method).Str("file", file).Err(err).Msg("Failed to parse route")
+				s.Log.Error().Str("path", route.Path).Str("method", route.Method).Str("file", file).Int("line", line).Err(err).Msg("Failed to parse route")
 				return err
 			}
 		}

--- a/utils/ast.go
+++ b/utils/ast.go
@@ -33,3 +33,10 @@ func SplitIdentSelectorExpr(expr ast.Expr, defaultPkgName string) ParseResult {
 
 	return ParseResult{}
 }
+
+func FuncDeclToFuncLit(expr *ast.FuncDecl) *ast.FuncLit {
+	return &ast.FuncLit{
+		Type: expr.Type,
+		Body: expr.Body,
+	}
+}


### PR DESCRIPTION
Now we can utilise inline functions inside of the body of the function where you define the routes, examples are shown below:

```go	
r.GET("/health", func(c *gin.Context) {
        c.JSON(200, gin.H{
            "status": "ok",
        })
    })
```

```go	
health := func(c *gin.Context) {
        c.JSON(200, gin.H{
            "status": "ok",
        })
}

r.GET("/health", health)
```

*It will not work with functions assigned via `:=` inside other packages - this can be worked on in the future should user demand*